### PR TITLE
Support commiter name with spaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ if (autoAmend) {
 }
 
 const matchCommitter = commit.match(
-	/^committer (.*)( [0-9a-f]+)? <.* (\d{10} [+-]\d{4})$/m
+	/^committer (.*?)( [0-9a-f]+)? <.* (\d{10} [+-]\d{4})$/m
 );
 
 if (!matchCommitter || matchCommitter.length !== 4) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ if (autoAmend) {
 }
 
 const matchCommitter = commit.match(
-	/^committer (\w*)( [0-9a-f]+)? <.* (\d{10} [+-]\d{4})$/m
+	/^committer (.*)( [0-9a-f]+)? <.* (\d{10} [+-]\d{4})$/m
 );
 
 if (!matchCommitter || matchCommitter.length !== 4) {


### PR DESCRIPTION
It's possible for the git committer name to include spaces. Probably even likely among the vain set of users of this tool!

An example line from git output that this would match:
```
committer Joe Soap <joe.soap@example.com> 1692180880 +0200
```